### PR TITLE
feat: clone marquee slides for infinite effect

### DIFF
--- a/src/SliderProvider/context.tsx
+++ b/src/SliderProvider/context.tsx
@@ -20,6 +20,7 @@ export interface ISliderContext extends Omit<SliderProviderProps, 'children'> {
   isPaused?: boolean
   setIsPaused: (is: boolean) => void // eslint-disable-line no-unused-vars
   isDragging: boolean
+  marquee: boolean
 }
 
 export const SliderContext = createContext<ISliderContext>({} as ISliderContext);

--- a/src/SliderProvider/index.tsx
+++ b/src/SliderProvider/index.tsx
@@ -218,6 +218,7 @@ const SliderProvider: React.FC<SliderProviderProps> = (props) => {
     pauseOnHover,
     alignLastSlide,
     isDragging,
+    marquee: Boolean(marquee),
     id
   };
 

--- a/src/SliderTrack/index.tsx
+++ b/src/SliderTrack/index.tsx
@@ -21,12 +21,14 @@ const SliderTrack: React.FC<SliderTrackProps> = (props) => {
     sliderTrackRef,
     setScrollRatio,
     slideWidth,
+    slidesToShow,
     scrollable,
     scrollSnap,
     setIsPaused,
     pauseOnHover,
     alignLastSlide,
     isDragging,
+    marquee,
     autoPlay,
     id: idFromContext,
   } = sliderContext;
@@ -58,6 +60,34 @@ const SliderTrack: React.FC<SliderTrackProps> = (props) => {
     sliderTrackRef,
     getScrollRatio,
   ]);
+
+  // NOTE: adds infinite scroll when marquee is enabled
+  useEffect(() => {
+    const track = sliderTrackRef.current;
+    if (marquee && track) {
+      const clones = track?.querySelectorAll('.marquee-clone');
+      clones?.forEach(clone => clone.remove());
+
+      const firstSlide = track.firstElementChild;
+      if (firstSlide) {
+        let selectedSlide = firstSlide
+
+        for (let i = 0; i < slidesToShow; i++) {
+          if (i !== 0) {
+            selectedSlide = selectedSlide.nextSibling as HTMLElement;
+          }
+
+          const clone = selectedSlide.cloneNode(true) as HTMLElement;
+          clone.style.width = `${100 / slidesToShow}%`;
+          clone.classList.add('marquee-clone');
+
+          if (clone) {
+            track.appendChild(clone);
+          }
+        }
+      }
+    }
+  }, [sliderTrackRef, marquee, scrollSnap, slidesToShow]);
 
   // NOTE: handle updates to the track's current scroll, which could originate from either the user or the program
   useEffect(() => {


### PR DESCRIPTION
The feature previously snapped to the start when reaching the end, but now the last selected slides are duplicated to create an infinite and seamless effect. 

This could be a breaking change for some like me, who have patched this by duplicating the slides manually prior to passing them to the SliderTrack. Due to this, you may want to change this to a toggled feature in the SliderProvider.